### PR TITLE
Various changes made in my fork that you may or may not want

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - ruby-head
+  - jruby
+matrix:
+  allow_failures:
+    - rvm: jruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source 'http://rubygems.org'
+source "https://rubygems.org"
+
 gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2013 Artsy, Inc.
+Copyright (c) 2017 Abe Voelker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -105,5 +105,6 @@ Copyright & License
 MIT license. See [LICENSE](LICENSE) for details.
 
 (c) 2013 [Art.sy Inc.](http://artsy.github.com)
+(c) 2017 Abe Voelker
 
 [redis-namespace]: https://github.com/resque/redis-namespace

--- a/README.md
+++ b/README.md
@@ -26,20 +26,39 @@ Add this to your Gemfile:
 gem 'forgetsy', github: 'cavvia/forgetsy', branch: 'v0.2.7'
 ```
 
-Configuration
------
+## Setup
 
-You may want to change the Redis host and port Forgetsy connects to, or
-set various other options at startup.
+Forgetsy will default to using `Redis.current` for Redis commands, but can be
+configured to use a specific Redis client:
 
-Forgetsy has a `redis` setter which can be given a string or a Redis
-object. This means if you're already using Redis in your app, Forgetsy
-can re-use the existing connection.
+```ruby
+Forgetsy.redis = Redis.new(host: "10.0.1.1", port: 6380, db: 15)
+```
 
-String: `Forgetsy.redis = 'localhost:6379'`
+or a hash of options that will be passed to `Redis.new`:
 
-Redis: `Forgetsy.redis = Redis.current`
+```ruby
+Forgetsy.redis = { host: "10.0.1.1", port: 6380, db: 15 }
+```
 
+The hash options also support a special `namespace` key which will namespace all
+Forgetsy keys under a prefix using the [redis-namespace][] gem. For example:
+
+```ruby
+Forgetsy.redis = { host: "localhost", port: 6379, db: 1, namespace: "forgetsy" }
+```
+
+which is equivalent to:
+
+```ruby
+require "redis-namespace"
+client = Redis.new(host: "localhost", port: 6379, db: 1)
+Forgetsy.redis = Redis::Namespace.new(:forgetsy, redis: client)
+```
+
+Note that if you are using the `namespace` key you are responsible for adding
+the `redis-namespace` gem to your project's Gemfile - this gem doesn't
+list it as a dependency.
 
 Usage
 -----
@@ -86,3 +105,5 @@ Copyright & License
 MIT license. See [LICENSE](LICENSE) for details.
 
 (c) 2013 [Art.sy Inc.](http://artsy.github.com)
+
+[redis-namespace]: https://github.com/resque/redis-namespace

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,5 @@ desc "Run all tests"
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = "spec/*_spec.rb"
 end
+
+task :default => "spec"

--- a/forgetsy.gemspec
+++ b/forgetsy.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'fakeredis'
+  gem.add_development_dependency 'timecop'
 end

--- a/forgetsy.gemspec
+++ b/forgetsy.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'redis', '> 2.0'
   gem.add_runtime_dependency 'redis-namespace', '>= 1.1.0'
   gem.add_runtime_dependency 'activesupport', '>= 3.2.0'
-  gem.add_development_dependency 'rspec', '~> 2.13.0'
-  gem.add_development_dependency 'rake', '~> 0.9'
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'fakeredis'
 end

--- a/forgetsy.gemspec
+++ b/forgetsy.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'redis', '> 2.0'
   gem.add_runtime_dependency 'redis-namespace', '>= 1.1.0'
-  gem.add_runtime_dependency 'activesupport', '>= 3.2.0'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'fakeredis'

--- a/forgetsy.gemspec
+++ b/forgetsy.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
 
-  gem.add_runtime_dependency 'redis', '> 2.0'
-  gem.add_runtime_dependency 'redis-namespace', '>= 1.1.0'
+  gem.add_runtime_dependency 'redis', '>= 2.0.12'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'fakeredis'
   gem.add_development_dependency 'timecop'
+  gem.add_development_dependency 'redis-namespace', '>= 1.1.0'
 end

--- a/lib/forgetsy.rb
+++ b/lib/forgetsy.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext'
-
 require 'forgetsy/set'
 require 'forgetsy/delta'
 

--- a/lib/forgetsy.rb
+++ b/lib/forgetsy.rb
@@ -1,42 +1,53 @@
-require 'forgetsy/set'
-require 'forgetsy/delta'
-
-require 'redis/namespace'
+# frozen_string_literal: true
+require "forgetsy/set"
+require "forgetsy/delta"
+require "logger"
+require "redis"
 
 module Forgetsy
-  extend self
-
   # Accepts:
-  #   1. A 'hostname:port' string
-  #   2. A 'hostname:port:db' string (to select the Redis db)
-  #   3. A 'hostname:port/namespace' string (to set the Redis namespace)
-  #   4. A redis URL string 'redis://host:port'
-  #   5. An instance of `Redis`, `Redis::Client`, `Redis::DistRedis`,
-  #      or `Redis::Namespace`.
-  def redis=(server)
-    if server.respond_to? :split
-      if server["redis://"]
-        redis = Redis.connect(:url => server, :thread_safe => true)
+  #   1. An instance of `Redis`, `Redis::Client`, `Redis::DistRedis`,
+  #      `Redis::Namespace`, etc. (i.e. an existing Redis client instance)
+  #   2. A hash of options to pass through to `Redis.new`. If a `:namespace`
+  #      key is also provided, that will not be passed through to `Redis.new`
+  #      but rather used to initialize a `Redis::Namespace`.
+  def self.redis=(options)
+    if options.is_a?(Hash)
+      namespace = options.delete(:namespace)
+      client = Redis.new(options)
+      if namespace
+        begin
+          require "redis/namespace"
+          @redis = Redis::Namespace.new(namespace, :redis => client)
+        rescue LoadError
+          self.logger.error("Your Redis configuration uses the namespace " \
+            "'#{namespace}' but the redis-namespace gem is not included in " \
+            "the Gemfile. Add the gem to your Gemfile to continue using a " \
+            "namespace. Otherwise, remove the namespace parameter.")
+          raise
+        end
       else
-        server, namespace = server.split('/', 2)
-        host, port, db = server.split(':')
-        redis = Redis.new(:host => host, :port => port, :thread_safe => true, :db => db)
+        @redis = client
       end
-      namespace ||= :forgetsy
-
-      @redis = Redis::Namespace.new(namespace, :redis => redis)
-    elsif server.respond_to? :namespace=
-      @redis = server
     else
-      @redis = Redis::Namespace.new(:forgetsy, :redis => server)
+      # Assume `options` is an already-initialized Redis client instance
+      @redis = options
     end
   end
 
-  # Returns the current Redis connection. If none has been created, will
-  # create a new one.
-  def redis
-    return @redis if @redis
-    self.redis = 'localhost:6379'
-    self.redis
+  def self.redis
+    defined?(@redis) ? @redis : (@redis = Redis.current)
+  end
+
+  def self.logger
+    defined?(@logger) ? @logger : initialize_logger
+  end
+
+  def self.initialize_logger(log_target = STDOUT)
+    oldlogger = defined?(@logger) ? @logger : nil
+    @logger = Logger.new(log_target)
+    @logger.level = Logger::INFO
+    oldlogger.close if oldlogger
+    @logger
   end
 end

--- a/lib/forgetsy/delta.rb
+++ b/lib/forgetsy/delta.rb
@@ -41,7 +41,7 @@ module Forgetsy
     def self.create(name, opts = {})
       unless opts.key?(:t)
         raise ArgumentError,
-             "Please specify a mean lifetime using the 't' option"
+             "Please specify a mean lifetime using the 't' option".freeze
       end
 
       if opts[:replay]
@@ -58,7 +58,7 @@ module Forgetsy
       delta = Forgetsy::Delta.new(name)
       unless delta.exists?
         raise NameError,
-             'No delta with that name exists'
+             "No delta with that name exists".freeze
       end
       delta
     end

--- a/lib/forgetsy/delta.rb
+++ b/lib/forgetsy/delta.rb
@@ -126,7 +126,7 @@ module Forgetsy
     end
 
     def exists?
-      @conn.exists(@name)
+      @conn.hexists(Forgetsy::Set::METADATA_KEY, "#{primary_set_key}:#{Forgetsy::Set::LIFETIME_KEY}")
     end
 
     private

--- a/lib/forgetsy/delta.rb
+++ b/lib/forgetsy/delta.rb
@@ -5,14 +5,13 @@ module Forgetsy
   # from two Forgetsy::Set instances decaying at
   # differing rates.
   class Delta
-    attr_accessor :name, :conn
+    attr_accessor :name
     # the time multiplier to use for the
     # normalising set.
     NORM_T_MULT = 2
 
     def initialize(name, opts = {})
       @name = name
-      setup_conn
 
       if opts.key?(:t)
         # we set the last decayed date of the secondary set to older than
@@ -126,14 +125,13 @@ module Forgetsy
     end
 
     def exists?
-      @conn.hexists(Forgetsy::Set::METADATA_KEY, "#{primary_set_key}:#{Forgetsy::Set::LIFETIME_KEY}")
+      Forgetsy.redis.hexists(
+        Forgetsy::Set::METADATA_KEY,
+        "#{primary_set_key}:#{Forgetsy::Set::LIFETIME_KEY}"
+      )
     end
 
     private
-
-    def setup_conn
-      @conn ||= Forgetsy.redis
-    end
 
     def primary_set_key
       @name

--- a/lib/forgetsy/delta.rb
+++ b/lib/forgetsy/delta.rb
@@ -75,8 +75,7 @@ module Forgetsy
 
       # do not delegate the limit to sets
       # as we want to apply the limit after norm.
-      limit = opts[:n]
-      opts.delete(:n)
+      limit = opts.delete(:n)
       bin = opts.key?(:bin) ? opts[:bin] : nil
 
       if bin.nil?
@@ -93,15 +92,15 @@ module Forgetsy
         norm = secondary_set.fetch(opts)
 
         if norm[bin].nil?
-          result = [bin, nil]
+          result = [[bin, nil]]
         else
           norm_v = counts[bin] / Float(norm[bin])
-          result = [bin, norm_v]
+          result = [[bin, norm_v]]
         end
       end
 
       result = result[0..limit - 1] unless limit.nil?
-      Hash[*result.flatten]
+      Hash[result.map{ |r| [r[0], r[1]] }]
     end
 
     # Increment a bin. Additionally supply a date option

--- a/lib/forgetsy/set.rb
+++ b/lib/forgetsy/set.rb
@@ -58,12 +58,12 @@ module Forgetsy
       scrub if opts.fetch(:scrub, true)
 
       if opts.key?(:bin)
-        result = [opts[:bin], @conn.zscore(@name, opts[:bin])]
+        result = [[opts[:bin], @conn.zscore(@name, opts[:bin])]]
       else
         result = fetch_raw(limit: limit)
       end
 
-      Hash[*result.flatten]
+      Hash[result.map{ |r| [r[0], r[1]] }]
     end
 
     # Apply exponential time decay and

--- a/lib/forgetsy/set.rb
+++ b/lib/forgetsy/set.rb
@@ -141,7 +141,7 @@ module Forgetsy
     end
 
     def valid_incr_date(date)
-      date && date.to_f > last_decayed_date.to_f
+      date && date.to_f >= last_decayed_date.to_f
     end
   end
 end

--- a/lib/forgetsy/set.rb
+++ b/lib/forgetsy/set.rb
@@ -4,11 +4,11 @@ module Forgetsy
   class Set
     attr_accessor :name, :conn
 
-    @@last_decayed_key = '_last_decay'
-    @@lifetime_key = '_t'
+    LAST_DECAYED_KEY = "_last_decay".freeze
+    LIFETIME_KEY = "_t".freeze
 
     # scrub keys scoring lower than this.
-    @@hi_pass_filter = 0.0001
+    HIGH_PASS_FILTER = 0.0001
 
     def initialize(name)
       @name = name
@@ -26,7 +26,7 @@ module Forgetsy
     def self.create(name, opts = {})
       unless opts.key?(:t)
         raise ArgumentError,
-             "Please specify a mean lifetime using the 't' option"
+             "Please specify a mean lifetime using the 't' option".freeze
       end
 
       date = opts[:date] || Time.now
@@ -84,7 +84,7 @@ module Forgetsy
     end
 
     def scrub
-      @conn.zremrangebyscore(@name, '-inf', @@hi_pass_filter)
+      @conn.zremrangebyscore(@name, "-inf".freeze, HIGH_PASS_FILTER)
     end
 
     def incr(bin, opts = {})
@@ -98,19 +98,19 @@ module Forgetsy
     end
 
     def last_decayed_date
-      @conn.zscore(@name, @@last_decayed_key)
+      @conn.zscore(@name, LAST_DECAYED_KEY)
     end
 
     def lifetime
-      @conn.zscore(@name, @@lifetime_key)
+      @conn.zscore(@name, LIFETIME_KEY)
     end
 
     def create_lifetime_key(t)
-      @conn.zadd(@name, t.to_f, @@lifetime_key)
+      @conn.zadd(@name, t.to_f, LIFETIME_KEY)
     end
 
     def update_decay_date(date)
-      @conn.zadd(@name, date.to_f, @@last_decayed_key)
+      @conn.zadd(@name, date.to_f, LAST_DECAYED_KEY)
     end
 
     private
@@ -133,7 +133,7 @@ module Forgetsy
     end
 
     def special_keys
-      [@@lifetime_key, @@last_decayed_key]
+      [LIFETIME_KEY, LAST_DECAYED_KEY]
     end
 
     def filter_special_keys(set)

--- a/spec/connect_spec.rb
+++ b/spec/connect_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+def redis_params(r)
+  r.options.select{|k,_| [:url, :host, :port, :db].include?(k)}
+end
+
+describe "Forgetsy" do
+  describe "connection" do
+    before do
+      @conn_backup = Forgetsy.instance_variable_get(:@redis)
+      Forgetsy.remove_instance_variable(:@redis)
+    end
+    after do
+      Forgetsy.instance_variable_set(:@redis, @conn_backup)
+    end
+
+    describe "without connection params provided" do
+      it "creates a default client using Redis.current" do
+        expect(Forgetsy.redis).to be(Redis.current)
+        expect(Forgetsy.redis).to be_a(::Redis)
+        expect(redis_params(Forgetsy.redis)).to eq({
+          url: nil,
+          host: "127.0.0.1",
+          port: 6379,
+          db: 0,
+        })
+      end
+    end
+
+    describe "with connection params provided" do
+      before do
+        Forgetsy.redis = redis_opts
+      end
+
+      describe "using a Redis instance" do
+        let(:redis_opts) { Redis.new(url: "redis://localhost:6380/5") }
+
+        it "sets up client correctly" do
+          expect(Forgetsy.redis).to be_a(::Redis)
+          expect(redis_params(Forgetsy.redis)).to eq({
+            url: "redis://localhost:6380/5",
+            host: "localhost",
+            port: 6380,
+            db: 5,
+          })
+        end
+      end
+
+      describe "using a params hash without namespace" do
+        let(:redis_opts) { {host: "10.0.1.1", db: 3} }
+
+        it "sets up client correctly" do
+          expect(Forgetsy.redis).to be_a(::Redis)
+          expect(redis_params(Forgetsy.redis)).to eq({
+            url: nil,
+            host: "10.0.1.1",
+            port: 6379,
+            db: 3,
+          })
+        end
+      end
+
+      describe "using a params hash with namespace" do
+        let(:redis_opts) { {host: "10.0.1.2", port: 6381, db: 2, namespace: "foo"} }
+
+        it "sets up client correctly" do
+          expect(Forgetsy.redis).to be_a(::Redis::Namespace)
+          expect(Forgetsy.redis.namespace).to eq("foo")
+          expect(Forgetsy.redis.redis).to be_a(::Redis)
+          expect(redis_params(Forgetsy.redis.redis)).to eq({
+            url: nil,
+            host: "10.0.1.2",
+            port: 6381,
+            db: 2,
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -4,12 +4,15 @@ describe "Forgetsy::Set" do
 
   before(:each) do
     @redis = Forgetsy.redis
-    @set = Forgetsy::Set.create('foo', t: WEEK)
+    @freezetime = Time.now
+    Timecop.freeze(@freezetime) do
+      @set = Forgetsy::Set.create('foo', t: WEEK)
+    end
   end
 
   describe 'creation' do
-    it 'creates a redis set with the appropriate name and stores metadata' do
-      @redis.zcount('foo', '-inf', '+inf').should == 2
+    it "creates the metadata hash" do
+      expect(@redis.hgetall("_forgetsy")).to eq({"foo:_last_decay"=>@freezetime.to_f.to_s, "foo:_t"=>"604800.0"})
     end
 
     it 'stores the last decayed date in a special key upon creation' do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -53,6 +53,14 @@ describe "Forgetsy::Set" do
       @set.incr('foo_bin', date: Time.now - 3 * WEEK)
       @set.fetch(bin: 'foo_bin').values.first.should == nil
     end
+
+    it 'increments counters when the set is created at the same time as the increment' do
+      manual_date = Time.now - 2 * WEEK
+      lifetime = 2 * WEEK
+      @set = Forgetsy::Set.create('foo', t: lifetime, date: manual_date)
+      @set.incr('foo_bin', date: manual_date)
+      @set.fetch(bin: 'foo_bin').values.first.should_not == nil
+    end
   end
 
   describe 'fetch' do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -13,9 +13,11 @@ describe "Forgetsy::Set" do
     end
 
     it 'stores the last decayed date in a special key upon creation' do
-      manual_date = 3.weeks.ago
-      a = Forgetsy::Set.create('bar', t: 1.week, date: manual_date)
-      a.last_decayed_date.should == manual_date.to_f.round(7)
+      Timecop.freeze(Time.now) do
+        manual_date = 3.weeks.ago
+        a = Forgetsy::Set.create('bar', t: 1.week, date: manual_date)
+        a.last_decayed_date.should == manual_date.to_f
+      end
     end
 
     it 'stores the mean lifetime in a special key upon creation' do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -80,6 +80,13 @@ describe "Forgetsy::Set" do
       @set.incr_by('bar_bin', 1)
       @set.fetch(decay: false).should == { 'foo_bin' => 2.0, 'bar_bin' => 1.0 }
     end
+
+    it "doesn't error on large set cardinality" do
+      @set.stub(:fetch_raw) do |args|
+        (1..70000).to_a.map{|i| [i.to_s, 1.0]}
+      end
+      expect{@set.fetch()}.to_not raise_error(SystemStackError)
+    end
   end
 
   describe 'decay' do

--- a/spec/set_spec.rb
+++ b/spec/set_spec.rb
@@ -76,23 +76,25 @@ describe "Forgetsy::Set" do
 
   describe 'decay' do
     it 'decays counts exponentially' do
-      manual_date = 2.days.ago
       now = Time.now
-      time_delta = now - manual_date
-      lifetime = 1.week
-      foo, bar = 2, 10
+      Timecop.freeze(now) do
+        manual_date = 2.days.ago
+        time_delta = now - manual_date
+        lifetime = 1.week
+        foo, bar = 2, 10
 
-      rate = 1 / Float(lifetime)
-      @set = Forgetsy::Set.create('foo', t: lifetime, date: manual_date)
-      @set.incr_by('foo_bin', foo)
-      @set.incr_by('bar_bin', bar)
+        rate = 1 / Float(lifetime)
+        @set = Forgetsy::Set.create('foo', t: lifetime, date: manual_date)
+        @set.incr_by('foo_bin', foo)
+        @set.incr_by('bar_bin', bar)
 
-      decayed_foo = foo * Math.exp(- rate * time_delta)
-      decayed_bar = bar * Math.exp(- rate * time_delta)
+        decayed_foo = foo * Math.exp(- rate * time_delta)
+        decayed_bar = bar * Math.exp(- rate * time_delta)
 
-      @set.decay(date: now)
-      @set.fetch(bin: 'foo_bin').values.first.round(3).should == decayed_foo.round(3)
-      @set.fetch(bin: 'bar_bin').values.first.round(3).should == decayed_bar.round(3)
+        @set.decay(date: now)
+        @set.fetch(bin: 'foo_bin').values.first.should == decayed_foo
+        @set.fetch(bin: 'bar_bin').values.first.should == decayed_bar
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "active_support"
 require File.expand_path("../../lib/forgetsy.rb", __FILE__)
 require "fakeredis/rspec"
+require "timecop"
 
 RSpec.configure do |c|
   c.before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
-require "active_support"
 require File.expand_path("../../lib/forgetsy.rb", __FILE__)
 require "fakeredis/rspec"
 require "timecop"
+
+SECOND = 1
+MINUTE = 60 * SECOND
+HOUR = 60 * MINUTE
+DAY = 24 * HOUR
+WEEK = 7 * DAY
+MONTH = 30 * DAY
 
 RSpec.configure do |c|
   c.before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
 require "active_support"
 require File.expand_path("../../lib/forgetsy.rb", __FILE__)
+require "fakeredis/rspec"
 
 RSpec.configure do |c|
-  c.before(:each) do
-    redis = Forgetsy.redis
-    redis.flushdb
+  c.before(:all) do
+    Forgetsy.redis = Redis.new
+  end
+
+  c.after(:each) do
+    Forgetsy.redis.flushdb
   end
 end


### PR DESCRIPTION
Hello, I made some modifications to this gem for use in my own project. Thought I'd open a PR in case you wanted any of them back upstream. Here are the changes I made:

* Use [fakeredis](http://guilleiguaran.github.io/fakeredis/) for testing Redis operations in-memory. When I first ran the test suite I didn't notice it was configured to use the real Redis instance running on `localhost:6379/0` and `FLUSHDB` emptied out unrelated data I had in Redis.
* Use [timecop](https://github.com/travisjeffery/timecop) for testing time-dependent calculations. This fixes some racy test failures and allows testing results with full precision rather than rounding.
* Remove ActiveSupport dependency, which seems to only be used in test helpers for `3.days.ago` type of things. These calculations can be done manually in the tests instead.
* Backported "Increment should be valid if the set is created at the exact same time as the first increment" (LessonPlanet/forgetsy@93e7b4ea45b7f28c1c4cf76c2bbd74b3df82dbf9)
* Fix for stack overflows on large set cardinality (modified backport from LessonPlanet/forgetsy@a6cd100f7bc23abf138d90ff7bee4b3bc239d7d0)
* Added a default Rake task and a .travis.yml to enable Travis-CI testing
* Rewrote some of the code to use constants instead of class variables and other little things like that, just personal taste

Backwards-incompatible changes:

* Store set metadata in a shared hash (key: "_forgetsy") rather than inside of each set's data. This eliminates the need to filter out junk data when fetching data from the sets. It also makes it easier to see metadata at a glance, and is a Redis best practice to use hashes when possible (https://redis.io/topics/memory-optimization#use-hashes-when-possible).
* Simplify the Redis client configuration to accept either an already-initialized client or a hash of options that get passed to Redis.new (i.e. let the redis-rb gem handle Redis config rather than trying to do it in this gem). Also remove the redis-namespace dependency from the gem, while still dynamically loading it if a :namespace option is provided (sidekiq also does it this way, that way people who don't use namespaces don't pull in an unneeded dependency).