### PR TITLE
Make retrospective spec replay

### DIFF
--- a/spec/delta_spec.rb
+++ b/spec/delta_spec.rb
@@ -21,7 +21,7 @@ describe "Forgetsy::Delta" do
 
   describe 'retrospective creation' do
     it 'sets last decay date of secondary set to older than that of the primary' do
-      delta = Forgetsy::Delta.create('foo', t: 1.week)
+      delta = Forgetsy::Delta.create('foo', t: 1.week, replay: true)
       delta.should be_kind_of(Forgetsy::Delta)
       primary_set = delta.primary_set
       secondary_set = delta.secondary_set


### PR DESCRIPTION
This spec only succeeded by chance—that the secondary set's initialization date took enough time to computer that it registered in as later than the primary's.